### PR TITLE
fix response writer to init and stand in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: go
 
 go:
-  - 1.4
+  - 1.6
 
 before_install:
-  - go get github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
 
 install:
   - go get -d -v ./...
   - go get github.com/bakins/test-helpers
 
 script:
-  - $HOME/gopath/bin/golint ./...
+  - golint ./...
   - go test -v ./...

--- a/middleware.go
+++ b/middleware.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 type (
@@ -64,7 +64,8 @@ func (h *Handler) Header() http.Header {
 func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 
-	h.handler.ServeHTTP(rw, r)
+	h.ResponseWriter = rw
+	h.handler.ServeHTTP(h, r)
 
 	latency := time.Since(start)
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -45,5 +45,5 @@ func TestHandler(t *testing.T) {
 
 	h.Assert(t, buf.Len() > 0, "buffer should not be empty")
 	h.Assert(t, strings.Contains(buf.String(), `"component":"homepage"`), "buffer did not match expected result")
-	h.Assert(t, lh.status == 200, "should have set status field in log to match response code")
+	h.Assert(t, lh.responseData.status == 200, "should have set status field in log to match response code")
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	h "github.com/bakins/test-helpers"
 )
 
@@ -45,4 +45,5 @@ func TestHandler(t *testing.T) {
 
 	h.Assert(t, buf.Len() > 0, "buffer should not be empty")
 	h.Assert(t, strings.Contains(buf.String(), `"component":"homepage"`), "buffer did not match expected result")
+	h.Assert(t, lh.status == 200, "should have set status field in log to match response code")
 }


### PR DESCRIPTION
Prior to this change the ResponseWriter on the Handler isn't initialized and
isn't used to intercept writes from the wrapped Handler. This results in
Handler.status never being set and always being reported as 200 in the log
messages, among probably other things.