### PR TITLE
use lowercase import of sirupsen/logrus to fix build errors due to to a case-only variation.

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/bakins/logrus-middleware"
 )
 

--- a/middleware.go
+++ b/middleware.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type (

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	h "github.com/bakins/test-helpers"
 )
 


### PR DESCRIPTION
This fixes #1