### PR TITLE
Fixed concurrency crash issue

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -75,6 +75,7 @@ func (h *Handler) Header() http.Header {
 func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 
+	h = h.m.Handler(h.handler, h.component)
 	h.ResponseWriter = rw
 	h.responseData = h.newResponseData()
 	h.handler.ServeHTTP(h, r)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -2,6 +2,7 @@ package logrusmiddleware
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -45,5 +46,8 @@ func TestHandler(t *testing.T) {
 
 	h.Assert(t, buf.Len() > 0, "buffer should not be empty")
 	h.Assert(t, strings.Contains(buf.String(), `"component":"homepage"`), "buffer did not match expected result")
-	h.Assert(t, lh.responseData.status == 200, "should have set status field in log to match response code")
+	var lr interface{}
+	err := json.Unmarshal([]byte(buf.String()), &lr)
+	h.Assert(t, err == nil, "could not decode log record")
+	h.Assert(t, lr.(map[string]interface{})["status"].(float64) == 200, "should have status field set in log to match response code")
 }


### PR DESCRIPTION
Logrus-middleware crashes under load when the handler replaces a ResponseWriter from one request with one from another concurrent request.

There are a number of log lines like this:

```
2018/04/20 15:40:18 http: multiple response.WriteHeader calls
```

Followed by 

```
fatal error: concurrent map writes
```

There's probably a better way to fix it than to clone the Handler for each request, but this works so far for my purposes.